### PR TITLE
ci(format): Astroのフォーマットはastroに任せる

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
 	"editor.defaultFormatter": "biomejs.biome",
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  },
 	"editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "never"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,6 +15,7 @@
 	},
 	"formatter": {
 		"enabled": true,
+		"ignore": ["./**/*.astro"],
 		"attributePosition": "multiline",
 		"indentStyle": "tab",
 		"indentWidth": 2,


### PR DESCRIPTION
biomeのformatterが対応していないため、AstroのVSCode拡張機能でフォーマットさせる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **設定変更**
  - [astro] 言語識別子のファイルに対して特定のエディタデフォルトフォーマッタを設定しました。
  - フォーマッタの設定に、`["./**/*.astro"]` を無視する規則を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->