### PR TITLE
feat: ダークモードに切り替えられるようにする

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
 	"editor.defaultFormatter": "biomejs.biome",
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  },
 	"editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "never"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,6 +15,7 @@
 	},
 	"formatter": {
 		"enabled": true,
+		"ignore": ["./**/*.astro"],
 		"attributePosition": "multiline",
 		"indentStyle": "tab",
 		"indentWidth": 2,

--- a/src/components/Meteors.tsx
+++ b/src/components/Meteors.tsx
@@ -17,6 +17,10 @@ export function Meteors({ number }: MeteorsProps) {
 		max: 0,
 	});
 
+	const [isLightTheme, setIsLightTheme] = useState(
+		document.documentElement.getAttribute('data-theme') === 'light',
+	);
+
 	useEffect(() => {
 		function handler() {
 			setOffset({
@@ -34,6 +38,18 @@ export function Meteors({ number }: MeteorsProps) {
 		};
 	}, []);
 
+	useEffect(() => {
+		function themeChangeHandler() {
+			setIsLightTheme(document.documentElement.getAttribute('data-theme') === 'light');
+		}
+
+		document.addEventListener('theme-change', themeChangeHandler);
+
+		return () => {
+			document.removeEventListener('theme-change', themeChangeHandler);
+		};
+	}, []);
+
 	return (
 		<div className='-z-10 absolute inset-0 h-40 w-full overflow-hidden motion-reduce:hidden'>
 			{meteors.map((_el, idx) => (
@@ -41,8 +57,12 @@ export function Meteors({ number }: MeteorsProps) {
 					aria-hidden={true}
 					key={idx}
 					className={cn(
-						'absolute h-0.5 w-0.5 rotate-[215deg] animate-meteor-effect rounded-full bg-gray-100 shadow-[0_0_0_1px_#ffffff10] motion-reduce:hidden dark:bg-gray-600',
-						'before:-translate-y-[50%] before:absolute before:top-1/2 before:h-0.5 before:w-14 before:transform before:rounded-full before:bg-gradient-to-r before:from-gray-300 before:to-transparent before:content-[""] dark:before:from-gray-600',
+						'absolute h-0.5 w-0.5 rounded-full shadow-[0_0_0_1px_#ffffff10] motion-reduce:hidden',
+						isLightTheme
+							? 'rotate-[45deg] bg-blue-900/30 before:bg-gradient-to-r before:from-blue-900/30'
+							: 'rotate-[215deg] bg-primary/30 before:bg-gradient-to-r before:from-primary/30',
+						'before:-translate-y-[50%] before:absolute before:top-1/2 before:h-0.5 before:w-14 before:transform before:rounded-full before:to-transparent before:content-[""]',
+						'animate-meteor-effect',
 					)}
 					style={{
 						top: `${Math.floor(Math.random() * 400 - 400)}px`,

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -4,16 +4,18 @@ import RssIcon from './rss-icon.astro';
 import SocialIcon from './social-icon/social-icon.astro';
 ---
 
-<footer class="bg-black">
-    <div class="max-w-screen-lg mx-auto px-4 py-3 text-white flex justify-between items-center">
-        <Copyright />
-        <div class="flex gap-3">
-            <SocialIcon icon="Github" />
-            <SocialIcon icon="X" />
-            <SocialIcon icon="Zenn" />
-            <SocialIcon icon="SpeakerDeck" />
-            <SocialIcon icon="SizuMe" />
-            <RssIcon />
-        </div>
+<footer class="bg-background border-t border-muted">
+  <div
+    class="max-w-screen-lg mx-auto px-4 py-3 text-foreground flex justify-between items-center"
+  >
+    <Copyright />
+    <div class="flex gap-3">
+      <SocialIcon icon="Github" />
+      <SocialIcon icon="X" />
+      <SocialIcon icon="Zenn" />
+      <SocialIcon icon="SpeakerDeck" />
+      <SocialIcon icon="SizuMe" />
+      <RssIcon />
     </div>
+  </div>
 </footer>

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -1,11 +1,15 @@
 ---
 import { Meteors } from './Meteors';
 import SiteLogo from './site-logo/site-logo.astro';
+import ThemeSelector from './theme-selector.astro';
 ---
 
 <header>
-	<div class="max-w-screen-lg mx-auto my-12 px-4">
-		<Meteors client:only="react" number={20} />
-		<SiteLogo />
-	</div>
+  <div class="max-w-screen-lg mx-auto my-12 px-4">
+    <Meteors client:only="react" number={20} />
+    <div class="flex justify-between items-center">
+      <SiteLogo />
+      <ThemeSelector />
+    </div>
+  </div>
 </header>

--- a/src/components/theme-provider.astro
+++ b/src/components/theme-provider.astro
@@ -1,0 +1,26 @@
+<script is:inline>
+  function getTheme() {
+    const storedTheme =
+      typeof localStorage !== "undefined" && localStorage.getItem("theme");
+
+    return (
+      storedTheme ||
+      (window.matchMedia("(prefers-color-scheme: light)").matches
+        ? "light"
+        : "dark")
+    );
+  }
+
+  function setTheme(newTheme) {
+    document.documentElement.dataset.theme = newTheme;
+    localStorage.setItem("theme", newTheme);
+  }
+
+  // set initial theme
+  setTheme(getTheme());
+  document.addEventListener("astro:after-swap", () => setTheme(getTheme()));
+
+  document.addEventListener("theme-change", (e) => {
+    setTheme(e.detail.theme);
+  });
+</script>

--- a/src/components/theme-selector.astro
+++ b/src/components/theme-selector.astro
@@ -1,0 +1,86 @@
+<theme-toggle class="relative h-6 w-6">
+  <button
+    id="toggle-theme"
+    class="group hover:opacity-70"
+    aria-label="Toggle Theme"
+  >
+    <span
+      class="absolute left-0 right-0 top-0 opacity-0 group-aria-pressed:opacity-100 text-primary"
+    >
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        ><g
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          ><circle cx="12" cy="12" r="4"></circle><path
+            d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
+          ></path></g
+        ></svg
+      >
+    </span>
+
+    <span
+      class="absolute left-0 right-0 top-0 opacity-0 group-aria-[pressed=false]:opacity-100 text-blue-900"
+    >
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        ><path
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 3a6 6 0 0 0 9 9a9 9 0 1 1-9-9"></path></svg
+      >
+    </span>
+  </button>
+</theme-toggle>
+
+<script>
+  class themeToggle extends HTMLElement {
+    constructor() {
+      super();
+      const button = this.querySelector("button") as HTMLButtonElement;
+
+      if (button) {
+        button.addEventListener("click", (e) => {
+          if (e.currentTarget instanceof HTMLButtonElement) {
+            const isPressed =
+              e.currentTarget.getAttribute("aria-pressed") === "true";
+            const themeChangeEvent = new CustomEvent("theme-change", {
+              detail: {
+                theme: isPressed ? "light" : "dark",
+              },
+            });
+            // dispatch event -> ThemeProvider.astro
+            document.dispatchEvent(themeChangeEvent);
+            button.setAttribute("aria-pressed", String(!isPressed));
+          }
+        });
+      }
+    }
+  }
+
+  if ("customElements" in window) {
+    customElements.define("theme-toggle", themeToggle);
+  }
+</script>
+
+<script is:inline>
+  const button = document.getElementById("toggle-theme");
+
+  function setButtonPresssed() {
+    const bodyThemeIsDark = document.documentElement.dataset.theme === "dark";
+    button.setAttribute("aria-pressed", String(bodyThemeIsDark));
+  }
+  setButtonPresssed();
+</script>

--- a/src/layouts/document.astro
+++ b/src/layouts/document.astro
@@ -1,23 +1,28 @@
 ---
-import '@fontsource-variable/lexend';
-import Footer from '../components/footer.astro';
-import Header from '../components/header.astro';
+import "@fontsource-variable/lexend";
+import "../stylesheet/globalStyles.css";
+import { ViewTransitions } from "astro:transitions";
+import Footer from "../components/footer.astro";
+import Header from "../components/header.astro";
+import ThemeProvider from "../components/theme-provider.astro";
 ---
 
 <!doctype html>
-<html lang='ja'>
-	<head>
-        <meta charset="utf-8">
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-	</head>
-	<body class="min-h-screen grid grid-rows-[auto_1fr_auto]">
-        <Header />
-        <main>
-            <div class="max-w-screen-lg mx-auto px-4">
-                <slot />
-            </div>
-        </main>
-        <Footer />
-	</body>
-</html
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <ViewTransitions />
+    <ThemeProvider />
+  </head>
+  <body class="min-h-screen grid grid-rows-[auto_1fr_auto]">
+    <Header />
+    <main>
+      <div class="max-w-screen-lg mx-auto px-4">
+        <slot />
+      </div>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/stylesheet/globalStyles.css
+++ b/src/stylesheet/globalStyles.css
@@ -1,0 +1,52 @@
+:root {
+    color-scheme: light dark;
+
+    --background: 0 0% 100%;
+    --foreground: 20 14.3% 4.1%;
+    --card: 0 0% 100%;
+    --card-foreground: 20 14.3% 4.1%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 20 14.3% 4.1%;
+    --primary: 47.9 95.8% 53.1%;
+    --primary-foreground: 26 83.3% 14.1%;
+    --secondary: 60 4.8% 95.9%;
+    --secondary-foreground: 24 9.8% 10%;
+    --muted: 60 4.8% 95.9%;
+    --muted-foreground: 25 5.3% 44.7%;
+    --accent: 60 4.8% 95.9%;
+    --accent-foreground: 24 9.8% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 60 9.1% 97.8%;
+    --border: 20 5.9% 90%;
+    --input: 20 5.9% 90%;
+    --ring: 20 14.3% 4.1%;
+    --radius: 0.5rem;
+}
+
+[data-theme="dark"]:root {
+    color-scheme: dark;
+
+    --background: 20 14.3% 4.1%;
+    --foreground: 60 9.1% 97.8%;
+    --card: 20 14.3% 4.1%;
+    --card-foreground: 60 9.1% 97.8%;
+    --popover: 20 14.3% 4.1%;
+    --popover-foreground: 60 9.1% 97.8%;
+    --primary: 47.9 95.8% 53.1%;
+    --primary-foreground: 26 83.3% 14.1%;
+    --secondary: 12 6.5% 15.1%;
+    --secondary-foreground: 60 9.1% 97.8%;
+    --muted: 12 6.5% 15.1%;
+    --muted-foreground: 24 5.4% 63.9%;
+    --accent: 12 6.5% 15.1%;
+    --accent-foreground: 60 9.1% 97.8%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 60 9.1% 97.8%;
+    --border: 12 6.5% 15.1%;
+    --input: 12 6.5% 15.1%;
+    --ring: 35.5 91.7% 32.9%;
+}
+
+[data-theme="light"]:root {
+    color-scheme: light;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,10 +3,51 @@ import defaultTheme from 'tailwindcss/defaultTheme'
 
 export default {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+	darkMode: false,
 	theme: {
 		extend: {
+			colors: {
+				border: "hsl(var(--border))",
+				input: "hsl(var(--input))",
+				ring: "hsl(var(--ring))",
+				background: "hsl(var(--background))",
+				foreground: "hsl(var(--foreground))",
+				primary: {
+				  DEFAULT: "hsl(var(--primary))",
+				  foreground: "hsl(var(--primary-foreground))",
+				},
+				secondary: {
+				  DEFAULT: "hsl(var(--secondary))",
+				  foreground: "hsl(var(--secondary-foreground))",
+				},
+				destructive: {
+				  DEFAULT: "hsl(var(--destructive))",
+				  foreground: "hsl(var(--destructive-foreground))",
+				},
+				muted: {
+				  DEFAULT: "hsl(var(--muted))",
+				  foreground: "hsl(var(--muted-foreground))",
+				},
+				accent: {
+				  DEFAULT: "hsl(var(--accent))",
+				  foreground: "hsl(var(--accent-foreground))",
+				},
+				popover: {
+				  DEFAULT: "hsl(var(--popover))",
+				  foreground: "hsl(var(--popover-foreground))",
+				},
+				card: {
+				  DEFAULT: "hsl(var(--card))",
+				  foreground: "hsl(var(--card-foreground))",
+				},
+			},
 			animation: {
 				'meteor-effect': 'meteor 5s linear infinite',
+			},
+			borderRadius: {
+				lg: "var(--radius)",
+				md: "calc(var(--radius) - 2px)",
+				sm: "calc(var(--radius) - 4px)",
 			},
 			keyframes: {
 				meteor: {


### PR DESCRIPTION
- **ci(format): Astroのフォーマットはastroに任せる**
- **feat(style): ダークテーマとライトテーマを切り替えられるようにした**
- **style(dark-mode): headerとfooterをダークモード対応色に変更**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - テーマ切り替え機能を導入し、ユーザーがライトテーマとダークテーマを切り替えられるようにしました。
  - `ThemeSelector`コンポーネントをヘッダーに追加し、テーマのトグル機能を提供。
  - 新しい`theme-provider.astro`ファイルでテーマ管理ロジックを実装。

- **スタイル**
  - フッターコンポーネントの背景色、境界線、テキスト色、配置を更新。
  - グローバルスタイルを定義する新しいCSSファイル`globalStyles.css`を追加。

- **改善**
  - VS Codeの設定で、`.astro`ファイルに対するフォーマッタ設定を更新。
  - `Meteors`コンポーネントがテーマ変更に応じて動的にスタイルを調整するように改良。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->