### PR TITLE
feat: ブログ一覧と表示用のブログカードを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "packageManager": "pnpm@9.5.0",
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
+    "@tailwindcss/typography": "0.5.13",
     "lefthook": "1.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.8.3
         version: 1.8.3
+      '@tailwindcss/typography':
+        specifier: 0.5.13
+        version: 0.5.13(tailwindcss@3.4.4)
       lefthook:
         specifier: 1.7.2
         version: 1.7.2
@@ -827,6 +830,11 @@ packages:
   '@shikijs/core@1.6.4':
     resolution: {integrity: sha512-WTU9rzZae1p2v6LOxMf6LhtmZOkIHYYW160IuahUyJy7YXPPjyWZLR1ag+SgD22ZMxZtz1gfU6Tccc8t0Il/XA==}
 
+  '@tailwindcss/typography@0.5.13':
+    resolution: {integrity: sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1557,6 +1565,15 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -1904,6 +1921,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.1:
     resolution: {integrity: sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==}
@@ -3100,6 +3121,14 @@ snapshots:
 
   '@shikijs/core@1.6.4': {}
 
+  '@tailwindcss/typography@0.5.13(tailwindcss@3.4.4)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.4
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.24.7
@@ -3949,6 +3978,12 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.castarray@4.4.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.merge@4.6.2: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.3.0
@@ -4448,6 +4483,11 @@ snapshots:
     dependencies:
       postcss: 8.4.38
       postcss-selector-parser: 6.1.1
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.1:
     dependencies:

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -1,0 +1,11 @@
+import { getCollection } from 'astro:content';
+
+// 記事一覧を取得。開発環境では下書きも取得する
+const blogEntries = await getCollection('blog', ({ data }) => {
+	return import.meta.env.PROD ? data.draft !== true : true;
+});
+const sortedBlogEntries = blogEntries.sort((a, b) => {
+	return b.data.publishDate.getTime() - a.data.publishDate.getTime();
+});
+
+export { sortedBlogEntries };

--- a/src/components/blog-card.astro
+++ b/src/components/blog-card.astro
@@ -1,0 +1,40 @@
+---
+import type { CollectionEntry } from "astro:content";
+import Link from "./link.astro";
+import MiniPost from "./mini-post.astro";
+import Time from "./time.astro";
+
+type Props = {
+  blog: CollectionEntry<"blog">;
+};
+
+const { blog } = Astro.props;
+---
+
+<article
+  class="grid gap-y-3 gap-x-6 grid-flow-row sm:grid-flow-col sm:grid-cols-[1fr_4fr] items-center"
+>
+  <div
+    class="relative rounded-xl bg-muted hover:opacity-70 cursor-pointer py-6 sm:py-3"
+  >
+    <MiniPost blog={blog} />
+    <Link to={blog.slug} className="absolute inset-0">
+      <span class="sr-only">{blog.data.title}</span>
+    </Link>
+  </div>
+  <section class="grid gap-y-1">
+    <h3>
+      <Link
+        className="leading-relaxed line-clamp-3 text-md sm:text-lg font-semibold text-foreground"
+        to={blog.slug}
+      >
+        {blog.data.title}
+      </Link>
+    </h3>
+    <div
+      class={"flex items-center gap-1 text-muted-foreground text-xs sm:text-sm"}
+    >
+      公開日: <Time date={blog.data.publishDate} />
+    </div>
+  </section>
+</article>

--- a/src/components/link.astro
+++ b/src/components/link.astro
@@ -1,0 +1,14 @@
+---
+import { cn } from "../utils/cn";
+
+type Props = {
+  to: string;
+  className?: string;
+};
+
+const { to, className } = Astro.props as Props;
+---
+
+<a href={to} class={cn("hover:opacity-75", className)}>
+  <slot />
+</a>

--- a/src/components/mini-post.astro
+++ b/src/components/mini-post.astro
@@ -1,0 +1,27 @@
+---
+import { type CollectionEntry, getEntry } from "astro:content";
+import Post from "../layouts/post.astro";
+
+type Props = {
+  blog: CollectionEntry<"blog">;
+};
+
+const { blog } = Astro.props;
+
+const entry = await getEntry("blog", blog.slug);
+const { Content } = await entry.render();
+---
+
+<aside
+  aria-hidden="true"
+  class="mx-auto overflow-hidden bg-background shadow-md w-[88px] h-[109.12px] rounded-sm"
+>
+  <div
+    class="pointer-events-none origin-top-left select-none"
+    style="transform: scale(0.179, 0.179);"
+  >
+    <Post title={blog.data.title} type="mini">
+      <Content />
+    </Post>
+  </div>
+</aside>

--- a/src/components/time.astro
+++ b/src/components/time.astro
@@ -1,0 +1,13 @@
+---
+import { cn } from "../utils/cn";
+
+type Props = {
+  date: Date;
+};
+
+const { date } = Astro.props;
+---
+
+<time datetime={date.toISOString()} class="tracking-wider">
+  {date.toLocaleDateString("ja-JP")}
+</time>

--- a/src/content/blog/what-is-react-dom-server-render-to-static-node-stream-is-deprecated.md
+++ b/src/content/blog/what-is-react-dom-server-render-to-static-node-stream-is-deprecated.md
@@ -1,0 +1,108 @@
+---
+publishDate: 2024-05-01
+title: Astro で Warning ReactDOMServer.renderToStaticNodeStream() is deprecated. が出るようになった原因と対応
+category: tech
+tags:
+  - Astro
+  - React
+  - Today I Learned
+---
+
+## Astro で突然非推奨の警告が出るようになった
+
+このサイトは Astro で実装されており、一部コンポーネントに React を使用しています。
+ある日を境に、開発サーバの起動ログに以下のような警告が出るようになりました。
+
+```
+Warning: ReactDOMServer.renderToStaticNodeStream() is deprecated. Use ReactDOMServer.renderToPipeableStream() and wait to `pipe` until the `onAllReady` callback has been called instead.
+```
+
+メッセージで検索してみると、同様の Issue が GitHub に起票されており、対応の Pull Request もマージされていました。
+
+https://github.com/withastro/astro/issues/10899
+
+<br />
+
+https://github.com/withastro/astro/pull/10893
+
+2024/05/01 時点ではまだリリースされていませんが、数日以内にリリースされると思われるため、@astrojs/react のバージョンアップで修正されると考えられます。
+
+> 2024/05/03 追記: 変更がリリースされ、警告が出なくなりました。
+> https://github.com/withastro/astro/blob/HEAD/packages/integrations/react/CHANGELOG.md#332
+
+この記事ではそもそもなぜこの警告が出るようになったのかを調査しました。
+
+## 前提
+
+- astro: 4.7.0
+- @astrojs/react 3.3.1
+- react 18.3.1
+- react-dom 18.3.1
+
+## どの箇所を起因として警告が出るようになったのか
+
+https://github.com/withastro/astro/blob/c238aa81ee91ce85f40740234fe6878faa27dceb/packages/integrations/react/server.js#L153-L173
+
+Astro の react インテグレーションで `ReactDOM.renderToStaticNodeStream()` が使用されている箇所がありました。
+
+https://github.com/facebook/react/pull/28874
+
+https://github.com/facebook/react/blob/main/CHANGELOG.md#react-dom
+
+React 側では 2024/04/25 の 18.3.0 のリリースでこの警告を追加しています。
+
+description を確認すると次の理由から非推奨に指定されたことがわかります。
+
+> This API has been legacy, is not widely used (renderToStaticMarkup is more common) and has semantically eqiuvalent implementations with renderToReadableStream and renderToPipeableStream.
+
+- `ReactDOM.renderToStaticMarkup()` がより一般的に使われている。
+- 加えて `ReactDOM.renderToReadableStream()` と `ReactDOM.renderToPipeableStream()` が同等の実装を持っている。
+
+## ReactDOMServer.renderToStaticNodeStream() とは何か？
+
+ReactDOMServer は、サーバ上で React コンポーネントをレンダリングするための API を指しており、具体的なパッケージは `react-dom/server` です。
+いわゆる Static-Site Generation や Server-Side Rendering と言われるような事前レンダリングに用いられます。
+
+https://ja.react.dev/reference/react-dom/server
+
+この API 群には動作環境とレンダリング結果の分類によっていくつかのメソッドが用意されているようです。
+
+| 環境                   | メソッド                   | ストリーム | ハイドレーション |
+| ---------------------- | -------------------------- | ---------- | ---------------- |
+| Node.js                | `renderToPipeableStream`   | 可         | 可               |
+| Node.js                | `renderToStaticNodeStream` | 可         | 不可             |
+| Web Stream             | `renderToReadableStream`   | 可         | 可               |
+| ストリームサポートなし | `renderToString`           | 不可       | 不可             |
+| ストリームサポートなし | `renderToStaticMarkup`     | 不可       | 不可             |
+
+上記の表の繰り返しになりますが、renderToStaticNodeStream は Node.js 環境において、React コンポーネントをストリームとして出力するための API を指します。
+
+## React ではなぜ ReactDOMServer.renderToStaticNodeStream() が非推奨となったのか
+
+ドキュメントを参照すると、注意点として以下の内容が記載されています。
+
+> renderToStaticNodeStream の出力はハイドレーションすることができません。
+> React 18 時点において、このメソッドはすべての出力をバッファリングするため、実際にはストリームを使用する利点が得られません。
+
+この特徴を踏まえると、`renderToStaticNodeStream` は実際にはストリームとしての利点を享受できないため、ケースによって既存のメソッドに置き換えることができそうです。
+
+- ハイドレーションが不要で、ストリームも不要な場合：`renderToStaticMarkup`
+- ハイドレーションが必要で、ストリームも必要な場合：`renderToPipeableStream`（Node.js環境）、`renderToReadableStream`（Web Stream）
+
+ユースケースをカバーできる他の API があるので、`renderToStaticNodeStream` は非推奨となったと考えられます。
+
+### 補足: Astro における対応
+
+```typescript
+if ("renderToReadableStream" in ReactDOM) {
+  html = await renderToReadableStreamAsync(vnode, renderOptions);
+} else {
+  html = await renderToPipeableStreamAsync(vnode, renderOptions);
+}
+```
+
+Astro では、環境に応じて `renderToReadableStream` か `renderToPipeableStream` を使うようになっていました。
+
+## 参考
+
+https://www.reddit.com/r/astrojs/comments/1cdbito/libsupabase_error_v46_and_v47_warning/?onetap_auto=true&one_tap=true&rdt=62227

--- a/src/content/blog/what-is-serving-ver-http-in-graphql.md
+++ b/src/content/blog/what-is-serving-ver-http-in-graphql.md
@@ -1,0 +1,106 @@
+---
+title: GraphQLの「Serving over HTTP」とは何か
+draft: false
+publishDate: 2024-05-03
+category: tech
+tags:
+  - GraphQL
+  - Today I Learned
+---
+
+## サマリ
+
+- モダンな Web アプリケーションフレームワークは、HTTPを用いてやり取りを行い、ミドルウェアを利用して認証やリクエストの検証、変換を行うパイプライン型のアーキテクチャを採用している
+- GraphQL においても、事前に認証・検証が行われた上でリクエストを処理するのがベストプラクティス
+- そのために、GraphQL のリクエストを REST のような形式でマッピングして処理する
+
+## Serving over HTTP
+
+https://graphql.org/learn/serving-over-http
+
+GraphQL サーバは GET と POST の 2 種類の HTTP リクエストをハンドリングできるようにします。
+
+マッピングされるパラメータは次のとおりです。
+
+| パラメータ    | 意味                                                           | 必須 |
+| ------------- | -------------------------------------------------------------- | ---- |
+| query         | クエリそのもの                                                 | 必須 |
+| variables     | クエリの変数                                                   | 任意 |
+| operationName | クエリの名前。複数のオペレーションを同時に実行する場合には必須 | 任意 |
+
+### GET
+
+GET リクエストでは、GraphQL Query が `query` というクエリパラメータにマッピングされます。
+
+```graphql
+query HeroQuery($id: ID!) {
+  hero(id: $id) {
+    name
+  }
+}
+```
+
+このクエリは、次のようにエンコードされます。
+
+```
+http://myapi.com/graphql?query=query($id: ID!){hero($id: ID!){name}}&operationName=HeroQuery&variables={"id":"avagfads732"}
+```
+
+### POST
+
+POST リクエストでは、`application/json` でリクエストを送信する。次の形式の JSON をボディとして送信されます。
+
+```json
+{
+  "query": "...",
+  "variables": "updateHeroName",
+  "operationName": { "id": "avagfads732", "name": "Andrew" }
+}
+```
+
+### レスポンス
+
+レスポンスは JSON 形式で返される。GraphQL の仕様に則り、`data`フィールドか`errors`フィールドが含まれます。
+
+```json
+{
+  "data": {
+    "hero": {
+      "name": "Andrew"
+    }
+  }
+}
+```
+
+```json
+{
+  "errors": [
+    {
+      "message": "Cannot query field 'hero' on type 'Query'",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+## [Draft] Transport Specification / GraphQL over HTTP
+
+ここまでの内容が GraphQL 公式で公開されている内容で、ここから先はまだドラフト段階です。
+
+### 仕様の定義場所
+
+https://graphql.github.io/graphql-over-http/draft/
+
+### 概要
+
+- GraphQL over HTTP は Serving over HTTP の仕様を拡張したもの。
+- HTTP サーバは 1 つ以上の URL を介して、GraphQL スキーマへのリクエストを受け付ける必要がある。
+- サーバおよびクライアントは、少なくとも JSON の形式でリクエストをサポートする必要がある。
+- レスポンスにおける Media Type は `application/graphql-response+json` が推奨。
+- サーバは POST リクエストに必ず対応する必要があり、そのほかの GET のようなメソッドも対応する可能性がある。
+- サーバはリクエストの処理の成功時にはその結果を、失敗時にはエラーを返す必要がある。

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from 'astro:content';
+
+const blogCollection = defineCollection({
+	type: 'content',
+	schema: z.object({
+		title: z.string(),
+		publishDate: z.date(),
+		category: z.enum(['tech', 'idea', 'life']).default('idea'),
+		draft: z.boolean().default(true),
+		tags: z.optional(z.array(z.string())),
+	}),
+});
+
+export const collections = {
+	blog: blogCollection,
+};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/layouts/post.astro
+++ b/src/layouts/post.astro
@@ -1,0 +1,26 @@
+---
+import { cn } from "../utils/cn";
+
+type PostLayoutProps = {
+  title: string;
+  type?: "normal" | "mini";
+};
+
+const { title, type = "normal" } = Astro.props as PostLayoutProps;
+---
+
+<div class={cn("p-14", type === "mini" && "w-[492px]")}>
+  <div class="text-lg">
+    {title}
+  </div>
+  <div
+    class={cn(
+      "mt-8 break-words",
+      type === "mini" && "text-[10px]",
+      "data-[theme='light']:prose",
+      "data-[theme='dark']:prose-invert"
+    )}
+  >
+    <slot />
+  </div>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,18 @@
 ---
-import Document from '../layouts/document.astro';
+import BlogCard from "../components/blog-card.astro";
+import Document from "../layouts/document.astro";
+
+import { sortedBlogEntries } from "../api/posts";
 ---
 
 <Document>
-  <p>ここにコンテンツが入ります</p>
+  <section class="grid gap-8">
+    <div class="grid grid-cols-2 items-center">
+      <h2 class="text-3xl font-bold text-foreground tracking-wider">BLOG</h2>
+      <p class="justify-self-end">次へ</p>
+    </div>
+    <div class="grid gap-y-8 sm:gap-y-4">
+      {sortedBlogEntries.map((blog) => <BlogCard blog={blog} />)}
+    </div>
+  </section>
 </Document>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -69,5 +69,7 @@ export default {
 			},
 		},
 	},
-	plugins: [],
+	plugins: [
+		require('@tailwindcss/typography'),
+	],
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ブログカードの表示コンポーネントを追加。
  - ミニブログ投稿の表示コンポーネントを追加。
  - フォーマットされた日付表示コンポーネントを追加。
  - 動的にスタイリングを調整する投稿レイアウトコンポーネントを追加。

- **その他**
  - Tailwind CSSのプラグインを追加し、タイポグラフィを強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->