### PR TITLE
fix: 長いタイトルでレイアウト崩れが起きるので改行方式を指定

### DIFF
--- a/src/components/blog-card.astro
+++ b/src/components/blog-card.astro
@@ -25,7 +25,7 @@ const { blog } = Astro.props;
   <section class="grid gap-y-1">
     <h3>
       <Link
-        className="leading-relaxed line-clamp-3 text-md sm:text-lg font-medium text-foreground"
+        className="leading-relaxed break-all line-clamp-3 text-md sm:text-lg font-medium text-foreground"
         to={blog.slug}
       >
         {blog.data.title}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `Link`コンポーネントの`className`属性に`break-all`を追加し、要素のスタイリングを変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->