### PR TITLE
style: ブログページのページネーションをstickyに変更

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -18,9 +18,8 @@ const { page } = Astro.props as {
 
 <Document>
   <section class="grid gap-8">
-    <h2 class="text-3xl font-bold text-foreground tracking-wider">BLOG</h2>
-    <div class="grid items-center">
-      <div class="justify-self-end">
+    <div class="grid items-center sticky top-0 backdrop-blur-sm z-20 py-4">
+      <div class="justify-self-end rounded-full">
         <Pagination page={page} collectionKey="blog" />
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Document from "../layouts/document.astro";
 import { getBlogs } from "../utils/blog";
 
 const allBlogs = await getBlogs();
-const blogs = allBlogs.slice(0, 5);
+const blogs = allBlogs.slice(0, 3);
 ---
 
 <Document>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ブログページのレイアウトを更新し、ページネーションコンポーネントの位置とスタイルを調整しました。

- **改良**
  - ホームページで表示されるブログ記事の数を5件から3件に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->